### PR TITLE
Raw Socket Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ supplied as either `InputStream` or `String` using the `:body` key.
 
 ### Streaming Responses
 
-Use `:as :stream` in the options map to make `:body` an `InputStream` to
-consume from.
+Use `:as :stream` in the options map to make `:body` an `java.io.InputStream` to
+consume from. Alternatively, use `:as :socket` to get access to the underlying
+`java.net.Socket` for bidirectional communication.
+
+Always make sure to call `close` on the resources obtained this way, otherwise
+you'll run into connection leaks.
 
 ### Exceptions
 

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
         unixsocket-http.impl.FixedPathUnixSocketFactory
         unixsocket-http.impl.FixedPathTcpSocket
         unixsocket-http.impl.FixedPathTcpSocketFactory
+        unixsocket-http.impl.SingletonSocketFactory
         unixsocket-http.impl.StreamingBody]
   :profiles {:dev {:dependencies [[org.nanohttpd/nanohttpd "2.3.1"]
                                   [org.clojure/test.check "1.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
         unixsocket-http.impl.FixedPathTcpSocket
         unixsocket-http.impl.FixedPathTcpSocketFactory
         unixsocket-http.impl.SingletonSocketFactory
+        unixsocket-http.impl.ResponseSocket
         unixsocket-http.impl.StreamingBody]
   :profiles {:dev {:dependencies [[org.nanohttpd/nanohttpd "2.3.1"]
                                   [org.clojure/test.check "1.0.0"]

--- a/src/unixsocket_http/client.clj
+++ b/src/unixsocket_http/client.clj
@@ -1,0 +1,114 @@
+(ns unixsocket-http.client
+  (:import [unixsocket_http.impl
+            FixedPathTcpSocketFactory
+            FixedPathUnixSocketFactory
+            SingletonSocketFactory]
+           [okhttp3
+            OkHttpClient
+            OkHttpClient$Builder]
+           [javax.net SocketFactory]
+           [java.net InetSocketAddress Socket URI]
+           [java.time Duration]))
+
+;; ## SocketFactory
+
+(defn- adapt-url
+  "Ensure backwards-compatibility by prefixing filesystem paths with `unix://`"
+  [^String url]
+  (if-not (re-matches #"[a-zA-Z]+://.*" url)
+    (do
+      (println "Calling unixsocket-http.core/client with a path instead of a URL is DEPRECATED.")
+      (str "unix://" url))
+    url))
+
+(defn- create-socket-factory
+  ^SocketFactory [^String uri-str]
+  (let [uri (URI. (adapt-url uri-str))]
+    (case (.getScheme uri)
+      "unix" (FixedPathUnixSocketFactory. (.getPath uri))
+      "tcp"  (FixedPathTcpSocketFactory. (.getHost uri) (.getPort uri))
+      (throw
+        (IllegalArgumentException.
+          (str "Can only handle URI schemes 'unix' and 'tcp', given: " uri-str))))))
+
+(defn- create-singleton-socket-factory
+  ^SingletonSocketFactory
+  [^String uri-str]
+  (SingletonSocketFactory.
+    (create-socket-factory uri-str)))
+
+;; ## OkHttpClient
+
+(defn- create-client
+  [^SocketFactory factory
+   {:keys [builder-fn
+           timeout-ms
+           read-timeout-ms
+           write-timeout-ms
+           connect-timeout-ms
+           call-timeout-ms]
+    :or {builder-fn identity
+         timeout-ms 0}}]
+   (let [default-timeout (Duration/ofMillis timeout-ms)
+         to-timeout #(or (some-> % Duration/ofMillis) default-timeout)
+         builder (doto (OkHttpClient$Builder.)
+                   (.connectTimeout (to-timeout connect-timeout-ms))
+                   (.callTimeout (to-timeout call-timeout-ms))
+                   (.readTimeout (to-timeout read-timeout-ms))
+                   (.writeTimeout (to-timeout write-timeout-ms))
+                   (builder-fn)
+                   (.socketFactory factory))
+         client (delay (.build builder))]
+     (.build builder)))
+
+;; ## Client Modes
+
+(defn- recreating-client
+  [url opts]
+  (fn [request]
+    (let [factory (create-singleton-socket-factory url)]
+      {::client (create-client factory opts)
+       ::socket (.getSocket factory)})))
+
+(defn- reusable-client
+  [url opts]
+  (let [client (-> (create-socket-factory url)
+                   (create-client opts))]
+    (fn [request]
+      (when (= (:as request) :socket)
+        (throw
+          (IllegalArgumentException.
+            (str "Client mode `:reuse` does not allow direct socket access.\n"
+                 "See documentation of `unixsocket-http.core/client`."))))
+      {::client client})))
+
+(defn- hybrid-client
+  "Client that will create a fresh connection when the raw socket is requested."
+  [url opts]
+  (let [fresh (recreating-client url opts)
+        client (reusable-client url opts)]
+    (fn [{:keys [as] :as request}]
+      (if (= as :socket)
+        (fresh request)
+        (client request)))))
+
+;; ## API
+
+(defn create
+  [url {:keys [mode] :or {mode :default} :as opts}]
+  (case mode
+    :reuse    (reusable-client url opts)
+    :recreate (recreating-client url opts)
+    :default  (hybrid-client url opts)))
+
+(defn connection
+  [{:keys [client] :as request}]
+  (client request))
+
+(defn get-client
+  ^OkHttpClient [connection]
+  (::client connection))
+
+(defn get-socket
+  ^Socket [connection]
+  (::socket connection))

--- a/src/unixsocket_http/core.clj
+++ b/src/unixsocket_http/core.clj
@@ -3,7 +3,9 @@
             [clojure.java.io :as io]
             [clojure.tools.logging :as log])
   (:refer-clojure :exclude [get])
-  (:import [unixsocket_http.impl StreamingBody]
+  (:import [unixsocket_http.impl
+            ResponseSocket
+            StreamingBody]
            [okhttp3
             HttpUrl
             HttpUrl$Builder
@@ -117,7 +119,9 @@
              (case as
                :string (.string body)
                :stream (.byteStream body)
-               :socket (client/get-socket connection)))})
+               :socket (ResponseSocket.
+                         (client/get-socket connection)
+                         response)))})
 
 (defn- handle-response
   [{:keys [status body] :as response}

--- a/src/unixsocket_http/impl/ResponseSocket.clj
+++ b/src/unixsocket_http/impl/ResponseSocket.clj
@@ -21,7 +21,7 @@
 
 (defn- get-response
   ^Response [^unixsocket_http.impl.ResponseSocket this]
-  (-> this (.-state)  (:object)))
+  (-> this (.-state)  (:response)))
 
 ;; ## Constructor
 
@@ -45,7 +45,5 @@
 
 (defn -close
   [this]
-  (try
-    (.close (get-response this))
-    (catch Exception _))
+  (.close (get-response this))
   (.close (get-socket this)))

--- a/src/unixsocket_http/impl/ResponseSocket.clj
+++ b/src/unixsocket_http/impl/ResponseSocket.clj
@@ -1,0 +1,51 @@
+(ns unixsocket-http.impl.ResponseSocket
+  "Wrapper around an existing socket that will make sure that the originating
+   OkHttp Response is closed when the socket is closed. Without this, we
+   run into connection leaks."
+  (:gen-class
+    :name            unixsocket_http.impl.ResponseSocket
+    :extends         java.net.Socket
+    :init            init
+    :state           state
+    :constructors    {[java.net.Socket okhttp3.Response] []})
+  (:require [unixsocket-http.impl.delegate :refer [delegate]]
+            [clojure.java.io :as io])
+  (:import [okhttp3 Response]
+           [java.net Socket]))
+
+;; ## State
+
+(defn- get-socket
+  ^Socket [^unixsocket_http.impl.ResponseSocket this]
+  (-> this (.-state) (:socket)))
+
+(defn- get-response
+  ^Response [^unixsocket_http.impl.ResponseSocket this]
+  (-> this (.-state)  (:object)))
+
+;; ## Constructor
+
+(defn -init
+  [^Socket socket ^Response response]
+  [[] {:socket   socket
+       :response response}])
+
+;; ## Methods
+
+(delegate
+  {:class  java.net.Socket
+   :via    get-socket
+   :except [connect close]})
+
+(defn -connect
+  ([this addr]
+   (.connect (get-socket this) addr))
+  ([this addr ^Integer timeout]
+   (.connect (get-socket this) addr timeout)))
+
+(defn -close
+  [this]
+  (try
+    (.close (get-response this))
+    (catch Exception _))
+  (.close (get-socket this)))

--- a/src/unixsocket_http/impl/SingletonSocketFactory.clj
+++ b/src/unixsocket_http/impl/SingletonSocketFactory.clj
@@ -1,0 +1,41 @@
+(ns unixsocket-http.impl.SingletonSocketFactory
+  "SocketFactory that produces `FixedPathTcpSocket` objects bound to a fixed path."
+  (:gen-class
+    :name            unixsocket_http.impl.SingletonSocketFactory
+    :extends         javax.net.SocketFactory
+    :init            init
+    :state           socket
+    :constructors    {[javax.net.SocketFactory] []}
+    :methods         [[getSocket [] java.net.Socket]])
+  (:import [java.net InetAddress InetSocketAddress Socket]
+           [javax.net SocketFactory]))
+
+;; ## Constructor
+
+(defn -init
+  [^SocketFactory factory]
+  [[] (delay (.createSocket factory))])
+
+;; ## Methods
+
+(defn- get-socket
+  ^Socket [^unixsocket_http.impl.SingletonSocketFactory this]
+  @(.-socket this))
+
+(defn -createSocket
+  ([this]
+   (get-socket this))
+  ([this ^InetAddress _ ^Integer _]
+   (doto (get-socket this)
+     (.connect (InetSocketAddress. 0))))
+  ([this ^InetAddress _ ^Integer _ ^InetAddress _ ^Integer _]
+   (doto (get-socket this)
+     (.connect (InetSocketAddress. 0)))))
+
+(defn -getSocket
+  [this]
+  (get-socket this))
+
+(defn -toString
+  [^unixsocket_http.impl.SingletonSocketFactory this]
+  (str (.-socket this)))

--- a/src/unixsocket_http/impl/SingletonSocketFactory.clj
+++ b/src/unixsocket_http/impl/SingletonSocketFactory.clj
@@ -1,5 +1,5 @@
 (ns unixsocket-http.impl.SingletonSocketFactory
-  "SocketFactory that produces `FixedPathTcpSocket` objects bound to a fixed path."
+  "Wrapper around a `SocketFactory` that will cache the created socket."
   (:gen-class
     :name            unixsocket_http.impl.SingletonSocketFactory
     :extends         javax.net.SocketFactory

--- a/test/unixsocket_http/nanohttpd.clj
+++ b/test/unixsocket_http/nanohttpd.clj
@@ -25,8 +25,7 @@
   ^NanoHTTPD []
   (proxy [NanoHTTPD] [0]
     (serve [^NanoHTTPD$IHTTPSession session]
-      (let [body (read-body session)
-            method (str (.getMethod session))]
+      (let [method (str (.getMethod session))]
         (case (.getUri session)
           "/ok"
           (NanoHTTPD/newFixedLengthResponse "OK")
@@ -38,7 +37,19 @@
           (NanoHTTPD/newFixedLengthResponse
             NanoHTTPD$Response$Status/OK
             "text/plain"
-            body)
+            (read-body session))
+
+          "/stream"
+          (let [len (-> (.getParameters session)
+                        ^java.util.List
+                        (.get "expect")
+                        (.get (int 0))
+                        (Integer/parseInt))]
+            (NanoHTTPD/newFixedLengthResponse
+              NanoHTTPD$Response$Status/OK
+              "application/octet-stream"
+              (.getInputStream session)
+              len))
 
           "/fail"
           (NanoHTTPD/newFixedLengthResponse


### PR DESCRIPTION
Duplex communication is necessary in cases like the one outlined [here](https://github.com/into-docker/clj-docker-client/blob/b711ea86cae4f813a6d8ff5e5e13e7e30ac417a7/README.md#attach-to-a-container-and-send-data-to-stdin).

This PR introduces a new `:mode` option when creating the client:
- `:reuse` will create a client that will rely on a reusable pool of connections,
- `:recreate` will create a client that will create a new connection for every request,
- `:default` will behave like a mixture of the two and only create a new connection when a request specifies `:as :socket`.

One thing needed to be addressed in a special way by the newly introduced `ResponseSocket` class:
- When returning the socket we cannot close `okhttp3.Response` (since that would close the underlying socket).
- If we naively return the socket we lose access to the response object and can thus not close it any more.
- Thus, we need a wrapper around the socket that makes sure to close both the socket and the underlying response when `.close()` is called.