### PR TITLE
Fix exception handling for '{:throw-exceptions nil}'

### DIFF
--- a/src/unixsocket_http/core.clj
+++ b/src/unixsocket_http/core.clj
@@ -48,10 +48,12 @@
 
 (defn- throw?
   [{:keys [status]}
-   {:keys [throw-exceptions throw-exceptions?]}]
+   {:keys [throw-exceptions throw-exceptions?]
+    :or {throw-exceptions  true
+         throw-exceptions? true}}]
   (and (>= status 400)
-       (not (false? throw-exceptions))
-       (not (false? throw-exceptions?))))
+       throw-exceptions
+       throw-exceptions?))
 
 (letfn [(without-body [{:keys [^java.io.Closeable body] :as response}]
           (.close body)

--- a/test/unixsocket_http/core_test.clj
+++ b/test/unixsocket_http/core_test.clj
@@ -227,8 +227,10 @@
 
 (defspec t-failing-request-without-exception (times 50)
   (prop/for-all
-    [request (->> (gen-fail-request)
-                  (gen/fmap #(assoc % :throw-exceptions false)))
+    [request (gen/let [req (gen-fail-request)
+                       k   (gen/elements [:throw-exceptions :throw-exceptions?])
+                       v   (gen/elements [nil false])]
+               (assoc req k v))
      send!   (gen-request-fn)]
     (let [{:keys [status body]} (send! request)]
       (and (= 500 status) (= "FAIL" body)))))


### PR DESCRIPTION
It should not throw (but does). This would break e.g.
`clj-docker-client`.