### PR TITLE
Repeating query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ supplied as either `InputStream` or `String` using the `:body` key.
 ;;  "{\"status\":\"Pulling from library/node\",\"id\":\"latest\"}\r\n..."}
 ```
 
+As this is supported by some APIs, you can pass a query parameter multiple times
+by supplying a collection instead of value. For example, `{:x [1 2 3]}` turns
+into `?x=1&x=2&x=3`.
+
 ### Streaming Responses
 
 Use `:as :stream` in the options map to make `:body` an `java.io.InputStream` to

--- a/src/unixsocket_http/data.clj
+++ b/src/unixsocket_http/data.clj
@@ -25,20 +25,27 @@
 
 ;; ## Request
 
+(defn- add-query-params!
+  [^HttpUrl$Builder builder {:keys [query-params]}]
+  (doseq [[k value-or-collection] query-params
+          v (if (coll? value-or-collection)
+              value-or-collection
+              [value-or-collection])]
+    (.addQueryParameter builder (name k) (str v))))
+
 (defn- build-url
   "Create URL to use for request. This will read the base URL from the
    client contained in the request in case the given url does not include
    a scheme and host."
   ^HttpUrl
-  [{:keys [url query-params] :as request}]
+  [{:keys [url] :as request}]
   (let [^HttpUrl$Builder builder (or (some-> (HttpUrl/parse url)
                                              (.newBuilder))
                                      (-> (str (client/base-url request)
                                               url)
                                          (HttpUrl/parse)
                                          (.newBuilder)))]
-    (doseq [[k v] query-params]
-      (.addQueryParameter builder (name k) (str v)))
+    (add-query-params! builder request)
     (.build builder)))
 
 (defn- build-body

--- a/test/unixsocket_http/data_test.clj
+++ b/test/unixsocket_http/data_test.clj
@@ -34,10 +34,20 @@
     (let [request (data/build-request
                     {:client       client
                      :method       :get
-                     :query-params {:x 1}
+                     :query-params {:x 1, :y "2"}
                      :url          url})]
       (is (= "GET" (.method request)))
-      (is (= (str url "/?x=1") (str (.url request))))
+      (is (= (str url "/?x=1&y=2") (str (.url request))))
+      (is (nil? (.body request)))))
+
+  (testing "request with repeating query parameters"
+    (let [request (data/build-request
+                    {:client       client
+                     :method       :get
+                     :query-params {:x [1 2 3]}
+                     :url          url})]
+      (is (= "GET" (.method request)))
+      (is (= (str url "/?x=1&x=2&x=3") (str (.url request))))
       (is (nil? (.body request)))))
 
   (testing "request with headers"


### PR DESCRIPTION
See #17. We might want to add a `:multi-param-style` option later on, should it be useful.