### PR TITLE
Test GraalVM continuously

### DIFF
--- a/.github/workflows/graalvm-compatibility.yml
+++ b/.github/workflows/graalvm-compatibility.yml
@@ -1,0 +1,40 @@
+name: graalvm-compatibility
+
+on:
+  push:
+    branches: ["main", "ci/*"]
+
+jobs:
+  build-graalvm:
+    strategy:
+      matrix:
+        build:
+          - "linux-amd64"
+          - "macos-amd64"
+        include:
+          - build: "linux-amd64"
+            os: "ubuntu-latest"
+          - build: "macos-amd64"
+            os: "macos-latest"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup-clojure
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          lein: 2.9.1
+      - name: setup-graalvm-ce
+        uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: "graalvm-community"
+          java-version: "21"
+
+      - name: compile-native-image
+        run: |
+          lein with-profile +graalvm-compatibility uberjar
+          native-image -jar target/compat.jar -o compat
+          chmod +x compat
+
+      - name: verify-result
+        run: ./compat

--- a/.github/workflows/graalvm-compatibility.yml
+++ b/.github/workflows/graalvm-compatibility.yml
@@ -23,7 +23,7 @@ jobs:
       - name: setup-clojure
         uses: DeLaGuardo/setup-clojure@3.5
         with:
-          lein: 2.9.1
+          lein: 2.10.0
       - name: setup-graalvm-ce
         uses: graalvm/setup-graalvm@v1
         with:

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,10 @@
             :year 2020
             :key "mit"
             :comment "MIT License"}
-  :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
+  :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [com.kohlschutter.junixsocket/junixsocket-common "2.8.0"]
-                 [com.kohlschutter.junixsocket/junixsocket-native-common "2.8.0"]
+                 [com.kohlschutter.junixsocket/junixsocket-common "2.8.1"]
+                 [com.kohlschutter.junixsocket/junixsocket-native-common "2.8.1"]
                  [com.squareup.okhttp3/okhttp "4.11.0"]
                  [org.jetbrains.kotlin/kotlin-stdlib-common "1.9.10"]]
   :exclusions [org.clojure/clojure]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject unixsocket-http "1.0.14-SNAPSHOT"
   :description "A library to allow HTTP calls over a UNIX socket, e.g. for
-                communicating with Docker."
+               communicating with Docker."
   :url "https://github.com/into-docker/unixsocket-http"
   :license {:name "MIT"
             :url "https://choosealicense.com/licenses/mit"
@@ -34,7 +34,18 @@
                              [org.clojure/java.classpath "1.0.0"]]}
              :ci
              [:kaocha
-              {:global-vars {*warn-on-reflection* false}}]}
+              {:global-vars {*warn-on-reflection* false}}]
+             :graalvm-compatibility
+             {:jar-name       "compat-base.jar"
+              :uberjar-name   "compat.jar"
+              :source-paths   ["test-graalvm/src"]
+              :resource-paths ["test-graalvm/resources"]
+              :global-vars    {*assert* false}
+              :jvm-opts       ["-Dclojure.compiler.direct-linking=true"
+                               "-Dclojure.spec.skip-macros=true"]
+              :dependencies   [[com.github.clj-easy/graal-build-time "1.0.5"]]
+              :main           compat.main
+              :aot            [compat.main]}}
   :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]
             "ci"     ["with-profile" "+ci" "run" "-m" "kaocha.runner"
                       "--reporter" "documentation"

--- a/test-graalvm/resources/META-INF/native-image/uhttp/uhttp/native-image.properties
+++ b/test-graalvm/resources/META-INF/native-image/uhttp/uhttp/native-image.properties
@@ -1,0 +1,7 @@
+Args = --no-fallback \
+       --report-unsupported-elements-at-runtime \
+       --features=clj_easy.graal_build_time.InitClojureClasses \
+       -H:+ReportExceptionStackTraces \
+       -J-Dclojure.spec.skip-macros=true \
+       -J-Dclojure.compiler.direct-linking=true \
+       -J-Xmx3g

--- a/test-graalvm/src/compat/main.clj
+++ b/test-graalvm/src/compat/main.clj
@@ -1,0 +1,64 @@
+(ns compat.main
+  (:gen-class)
+  (:require [unixsocket-http.core :as uhttp]
+            [clojure.java.io :as io])
+  (:import [org.newsclub.lib.junixsocket.common NarMetadata]
+           [org.newsclub.net.unix AFUNIXSocket]
+           [java.io File]
+           [java.util Properties]))
+
+(defn- junixsocket-version
+  []
+  (let [path "/META-INF/maven/com.kohlschutter.junixsocket/junixsocket-common/pom.properties"]
+    (with-open [in (.getResourceAsStream AFUNIXSocket path)]
+      (-> (doto (Properties.)
+            (.load in))
+          (.getProperty "version")))))
+
+(defn- arch-and-os
+  []
+  (let [arch    (System/getProperty "os.arch")
+        os      (-> (System/getProperty "os.name") (.replaceAll " " ""))]
+    ;; Look, this is a fix for Github Actions' MacOS runner. I know this is not
+    ;; pretty.
+    (case [arch os]
+      ["amd64" "MacOSX"] ["x86_64" "MacOSX"]
+      [arch os])))
+
+(defn run-selftest
+  "Attempt to load the native library."
+  []
+  (let [library   (System/mapLibraryName
+                    (str "junixsocket-native-" (junixsocket-version)))
+        [arch os] (arch-and-os)
+        path      (format "/lib/%s-%s-clang/jni/%s" arch os library)
+        tmp-dir   (System/getProperty "java.io.tmpdir")]
+    (println "Native Library: " library)
+    (println "  Architecture: " arch)
+    (println "  OS:           " os)
+    (println "  Path:         " path)
+    (println "  Temp Dir:     " tmp-dir)
+    (println "Loading native library ...")
+    (let [tmp-file (File/createTempFile "libtmp" library)
+          tmp-path (.getAbsolutePath tmp-file)
+          stream   (.getResourceAsStream NarMetadata path)]
+      (or (when stream
+            (println "  Copying to" tmp-path "...")
+            (with-open [stream stream
+                        out    (io/output-stream tmp-file)]
+              (io/copy stream out))
+            (println "  Loading" tmp-path "...")
+            (System/load (.getAbsolutePath tmp-file))
+            (println "  OK!")
+            :ok)
+          (do
+            (println "The native library could not be found.")
+            :fail)))))
+
+(defn -main
+  [& [socket-addr path]]
+  (if (and socket-addr path)
+    (let [client (uhttp/client socket-addr)]
+      (prn (uhttp/get client path)))
+    (when (= :fail (run-selftest))
+      (System/exit 1))))


### PR DESCRIPTION
Basically importing the code and Github Actions workflow from [uhttp](https://github.com/into-docker/uhttp) to verify GraalVM compatibility for the `main` and `ci/*` branches.